### PR TITLE
Fix synthetic event window

### DIFF
--- a/src/core/display.c
+++ b/src/core/display.c
@@ -1835,6 +1835,21 @@ event_callback (XEvent   *event,
       meta_display_process_key_event (display, window, event);
       break;
     case ButtonPress:
+      /* Use window under pointer when processing synthetic events from another client */
+      if (window == NULL && event->xbutton.send_event)
+        {
+          int x, y, root_x, root_y;
+          Window root, child;
+          guint mask;
+          XQueryPointer (display->xdisplay,
+                         event->xany.window,
+                         &root, &child,
+                         &root_x, &root_y,
+                         &x, &y,
+                         &mask);
+          window = meta_display_lookup_x_window (display, child);
+        }
+
       if ((window && !window->override_redirect &&
            meta_grab_op_is_mouse (display->grab_op) &&
            display->grab_button != (int) event->xbutton.button &&

--- a/src/core/keybindings.c
+++ b/src/core/keybindings.c
@@ -1268,6 +1268,15 @@ meta_display_process_key_event (MetaDisplay *display,
   if (meta_ui_window_is_widget (screen->ui, event->xany.window))
     return;
 
+  /* Use focused window when processing synthetic events from another client */
+  if (window == NULL && event->xkey.send_event)
+    {
+      Window focus = None;
+      int ret_to = RevertToPointerRoot;
+      XGetInputFocus (display->xdisplay, &focus, &ret_to);
+      window = meta_display_lookup_x_window (display, focus);
+    }
+
   keysym = keycode_to_keysym (display, event->xkey.keycode);
 
   /* was topic */


### PR DESCRIPTION
When a client is passively grabbing keys or mouse clicks that it does
not need, it sends them up for other clients to process (this sets the
`send_event` flag inside `XEvent`).

Often in this situation, the event contains the wrong window (either
root, for global keybindings, or the original client itself). This means
that Metacity will attempt to process the event for the wrong window.

This is not an issue for global bindings within Metacity, as the
focused/current window does not matter. However, for shortcuts that
operate directly on specific windows, the event gets lost.

This change addresses this issue by determining which is the
currently-focused (for key grabs), or under-the-pointer (for button
grabs), window, regardless of which client forwarded the event.

Reference: https://github.com/mate-desktop/marco/pull/342